### PR TITLE
add the GLOBAL_ACK_EINTR constant to the list of exported symbols

### DIFF
--- a/src/pycurl.c
+++ b/src/pycurl.c
@@ -3211,6 +3211,16 @@ static PyTypeObject CurlMulti_Type = {
      */
 };
 
+static int
+are_global_init_flags_valid(int flags)
+{
+#ifdef CURL_GLOBAL_ACK_EINTR
+    /* CURL_GLOBAL_ACK_EINTR was introduced in libcurl-7.30.0 */
+    return !(flags & ~(CURL_GLOBAL_ALL | CURL_GLOBAL_ACK_EINTR));
+#else
+    return !(flags & ~(CURL_GLOBAL_ALL));
+#endif
+}
 
 /*************************************************************************
 // module level
@@ -3228,10 +3238,7 @@ do_global_init(PyObject *dummy, PyObject *args)
         return NULL;
     }
 
-    if (!(option == CURL_GLOBAL_SSL ||
-          option == CURL_GLOBAL_WIN32 ||
-          option == CURL_GLOBAL_ALL ||
-          option == CURL_GLOBAL_NOTHING)) {
+    if (!are_global_init_flags_valid(option)) {
         PyErr_SetString(PyExc_ValueError, "invalid option to global_init");
         return NULL;
     }
@@ -3867,6 +3874,10 @@ initpycurl(void)
     insint(d, "GLOBAL_ALL", CURL_GLOBAL_ALL);
     insint(d, "GLOBAL_NOTHING", CURL_GLOBAL_NOTHING);
     insint(d, "GLOBAL_DEFAULT", CURL_GLOBAL_DEFAULT);
+#ifdef CURL_GLOBAL_ACK_EINTR
+    /* CURL_GLOBAL_ACK_EINTR was introduced in libcurl-7.30.0 */
+    insint(d, "GLOBAL_ACK_EINTR", CURL_GLOBAL_ACK_EINTR);
+#endif
 
 
     /* constants for curl_multi_socket interface */

--- a/tests/global_init_ack_eintr.py
+++ b/tests/global_init_ack_eintr.py
@@ -1,0 +1,22 @@
+#! /usr/bin/env python
+# -*- coding: iso-8859-1 -*-
+# vi:ts=4:et
+
+import pycurl
+import unittest
+
+from . import util
+
+class GlobalInitAckEintrTest(unittest.TestCase):
+    def test_global_init_default(self):
+        # initialize libcurl with DEFAULT flags
+        pycurl.global_init(pycurl.GLOBAL_DEFAULT)
+        pycurl.global_cleanup()
+
+    def test_global_init_ack_eintr(self):
+        # the GLOBAL_ACK_EINTR flag was introduced in libcurl-7.30, but can also
+        # be backported for older versions of libcurl at the distribution level
+        if not util.pycurl_version_less_than(7, 30) or hasattr(pycurl, 'GLOBAL_ACK_EINTR'):
+            # initialize libcurl with the GLOBAL_ACK_EINTR flag
+            pycurl.global_init(pycurl.GLOBAL_ACK_EINTR)
+            pycurl.global_cleanup()


### PR DESCRIPTION
... if built against a new enough version of libcurl

Signed-off-by: Kamil Dudka kdudka@redhat.com
