### PR TITLE
[RFE] support setopt(pycurl.RANGE, None)

### DIFF
--- a/src/pycurl.c
+++ b/src/pycurl.c
@@ -1631,12 +1631,10 @@ do_curl_setopt(CurlObject *self, PyObject *args)
     if (option % 10000 >= OPTIONS_SIZE)
         goto error;
 
-#if 0 /* XXX - should we ??? */
-    /* Handle the case of None */
+    /* Handle the case of None as the call of unsetopt() */
     if (obj == Py_None) {
         return util_curl_unsetopt(self, option);
     }
-#endif
 
     /* Handle the case of string arguments */
     if (PyString_Check(obj)) {

--- a/src/pycurl.c
+++ b/src/pycurl.c
@@ -1561,6 +1561,7 @@ util_curl_unsetopt(CurlObject *self, int option)
     case CURLOPT_RANDOM_FILE:
     case CURLOPT_SSL_CIPHER_LIST:
     case CURLOPT_USERPWD:
+    case CURLOPT_RANGE:
         SETOPT((char *) 0);
         break;
 

--- a/tests/unset_range_test.py
+++ b/tests/unset_range_test.py
@@ -37,3 +37,15 @@ class UnsetRangeTest(unittest.TestCase):
         self.curl.unsetopt(pycurl.RANGE)
         self.curl.perform()
         assert 10 < self.read
+
+        # now set the RANGE again and check that pycurl takes it into account
+        self.read = 0
+        self.curl.setopt(pycurl.RANGE, '0-9')
+        self.curl.perform()
+        assert 10 == self.read
+
+        # now drop the RANGE setting using setopt(..., None)
+        self.read = 0
+        self.curl.setopt(pycurl.RANGE, None)
+        self.curl.perform()
+        assert 10 < self.read

--- a/tests/unset_range_test.py
+++ b/tests/unset_range_test.py
@@ -1,0 +1,39 @@
+#! /usr/bin/env python
+# -*- coding: iso-8859-1 -*-
+# vi:ts=4:et
+
+import os.path
+import pycurl
+import sys
+import unittest
+
+class UnsetRangeTest(unittest.TestCase):
+    def setUp(self):
+        self.curl = pycurl.Curl()
+
+    def tearDown(self):
+        self.curl.close()
+
+    def test_unset_range(self):
+        def write_cb(data):
+            self.read += len(data)
+            return None
+
+        # download bytes 0-9 of the script itself through the file:// protocol
+        self.read = 0
+        self.curl.setopt(pycurl.URL, 'file://' + os.path.abspath(sys.argv[0]))
+        self.curl.setopt(pycurl.WRITEFUNCTION, write_cb)
+        self.curl.setopt(pycurl.RANGE, '0-9')
+        self.curl.perform()
+        assert 10 == self.read
+
+        # the RANGE setting should be preserved from the previous transfer
+        self.read = 0
+        self.curl.perform()
+        assert 10 == self.read
+
+        # drop the RANGE setting using unsetopt() and download entire script
+        self.read = 0
+        self.curl.unsetopt(pycurl.RANGE)
+        self.curl.perform()
+        assert 10 < self.read


### PR DESCRIPTION
- 401bc4b8f665ce5923a5a985a6e29a2d2778de44 allow to unset a previously set RANGE value
- 3cd619d3c6e7bc2870b2670660417e007ff1dccb allow to use setopt(..., None) as unsetopt()
