### PR TITLE
Add support for CURLOPT_USERNAME / _PASSWORD

### DIFF
--- a/src/pycurl.c
+++ b/src/pycurl.c
@@ -61,6 +61,13 @@
 #  error "Need libcurl version 7.19.0 or greater to compile pycurl."
 #endif
 
+#if LIBCURL_VERSION_MAJOR >= 8 || \
+    LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 20 || \
+    LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR == 19 && LIBCURL_VERSION_PATCH >= 1
+#define HAVE_CURLOPT_USERNAME
+#define HAVE_CURLOPT_PROXYUSERNAME
+#endif
+
 /* Python < 2.5 compat for Py_ssize_t */
 #if PY_VERSION_HEX < 0x02050000 && !defined(PY_SSIZE_T_MIN)
 typedef int Py_ssize_t;
@@ -1558,9 +1565,17 @@ util_curl_unsetopt(CurlObject *self, int option)
     case CURLOPT_EGDSOCKET:
     case CURLOPT_FTPPORT:
     case CURLOPT_PROXYUSERPWD:
+#ifdef HAVE_CURLOPT_PROXYUSERNAME
+    case CURLOPT_PROXYUSERNAME:
+    case CURLOPT_PROXYPASSWORD:
+#endif
     case CURLOPT_RANDOM_FILE:
     case CURLOPT_SSL_CIPHER_LIST:
     case CURLOPT_USERPWD:
+#ifdef HAVE_CURLOPT_USERNAME
+    case CURLOPT_USERNAME:
+    case CURLOPT_PASSWORD:
+#endif
     case CURLOPT_RANGE:
         SETOPT((char *) 0);
         break;
@@ -1658,6 +1673,10 @@ do_curl_setopt(CurlObject *self, PyObject *args)
         case CURLOPT_NETRC_FILE:
         case CURLOPT_PROXY:
         case CURLOPT_PROXYUSERPWD:
+#ifdef HAVE_CURLOPT_PROXYUSERNAME
+        case CURLOPT_PROXYUSERNAME:
+        case CURLOPT_PROXYPASSWORD:
+#endif
         case CURLOPT_RANDOM_FILE:
         case CURLOPT_RANGE:
         case CURLOPT_REFERER:
@@ -1671,6 +1690,10 @@ do_curl_setopt(CurlObject *self, PyObject *args)
         case CURLOPT_URL:
         case CURLOPT_USERAGENT:
         case CURLOPT_USERPWD:
+#ifdef HAVE_CURLOPT_USERNAME
+        case CURLOPT_USERNAME:
+        case CURLOPT_PASSWORD:
+#endif
         case CURLOPT_FTP_ALTERNATIVE_TO_USER:
         case CURLOPT_SSH_PUBLIC_KEYFILE:
         case CURLOPT_SSH_PRIVATE_KEYFILE:
@@ -3654,7 +3677,15 @@ initpycurl(void)
     insint_c(d, "PORT", CURLOPT_PORT);
     insint_c(d, "PROXY", CURLOPT_PROXY);
     insint_c(d, "USERPWD", CURLOPT_USERPWD);
+#ifdef HAVE_CURLOPT_USERNAME
+    insint_c(d, "USERNAME", CURLOPT_USERNAME);
+    insint_c(d, "PASSWORD", CURLOPT_PASSWORD);
+#endif
     insint_c(d, "PROXYUSERPWD", CURLOPT_PROXYUSERPWD);
+#ifdef HAVE_CURLOPT_PROXYUSERNAME
+    insint_c(d, "PROXYUSERNAME", CURLOPT_PROXYUSERNAME);
+    insint_c(d, "PROXYPASSWORD", CURLOPT_PROXYPASSWORD);
+#endif
     insint_c(d, "RANGE", CURLOPT_RANGE);
     insint_c(d, "INFILE", CURLOPT_READDATA);
     /* ERRORBUFFER is not supported */

--- a/tests/curlopt_test.py
+++ b/tests/curlopt_test.py
@@ -1,0 +1,18 @@
+#! /usr/bin/env python
+# -*- coding: iso-8859-1 -*-
+# vi:ts=4:et
+
+import pycurl
+import unittest
+import nose.tools
+
+from . import util
+
+class CurloptTest(unittest.TestCase):
+    def test_username(self):
+        # CURLOPT_USERNAME was introduced in libcurl-7.19.1
+        if not util.pycurl_version_less_than(7, 19, 1):
+            assert hasattr(pycurl, 'USERNAME')
+            assert hasattr(pycurl, 'PASSWORD')
+            assert hasattr(pycurl, 'PROXYUSERNAME')
+            assert hasattr(pycurl, 'PROXYPASSWORD')


### PR DESCRIPTION
Original patch by Wim Lewis (https://sourceforge.net/u/wiml/profile/).

Original patch description:

This is a really trivial patch to add support for the CURLOPT_USERNAME and
CURLOPT_PASSWORD options (and their _PROXY equivalents), which affect
the same parts of libcurl's state that CURLOPT_USERPWD does but which
don't require you to combine the username and password into one string first.
(Libcurl just immediately parses it apart again anyway.)

I've tested against libcurl-7.21.0, and looked through the source for
libcurl 7.20.0 and 7.19.5 to verify that it looks like it should still do
the right things there (in particular that curl_easy_setopt(..., NULL)
does the reasonable thing with these options).

https://sourceforge.net/p/pycurl/patches/10/
