### PR TITLE
Fixes invalid XHTML in documentation

### DIFF
--- a/doc/callbacks.html
+++ b/doc/callbacks.html
@@ -120,7 +120,7 @@ VERBOSE option must be enabled for this callback to be invoked.</p>
 </pre>
 
 <h2>Other examples</h2>
-The pycurl distribution also contains a number of test scripts and
+<p>The pycurl distribution also contains a number of test scripts and
 examples which show how to use the various callbacks in libcurl.
 For instance, the file 'examples/file_upload.py' in the distribution contains
 example code for using READFUNCTION, 'tests/test_cb.py' shows

--- a/doc/curlshareobject.html
+++ b/doc/curlshareobject.html
@@ -14,6 +14,7 @@
 
 <p>CurlShare objects have the following methods:</p>
 
+<dl>
 <dt><code>setopt(</code><em>option, value</em><code>)</code> -&gt; <em>None</em></dt>
 <dd>
 
@@ -22,7 +23,7 @@
 href="http://curl.haxx.se/libcurl/c/curl_share_setopt.html"><code>curl_share_setopt</code></a> in libcurl, where
 <em>option</em> is specified with the CURLSHOPT_* constants in libcurl,
 except that the CURLSHOPT_ prefix has been changed to SH_.  Currently,
-<em>value</em> must be either LOCK_DATA_COOKIE or LOCK_DATA_DNS.
+<em>value</em> must be either LOCK_DATA_COOKIE or LOCK_DATA_DNS.</p>
 
 <p>Example usage:</p>
 


### PR DESCRIPTION
doc/callbacks.html and doc/curlshareobject.html were not valid xhtml.

Thanks to Ivo Timmermans for the original report and patch to Ubuntu (LP: #364168)
