### PR TITLE
Fix a tiny memory leak in util_curl_init()

### DIFF
--- a/src/pycurl.c
+++ b/src/pycurl.c
@@ -793,8 +793,8 @@ util_curl_init(CurlObject *self)
     }
     strcpy(s, "PycURL/"); strcpy(s+7, LIBCURL_VERSION);
     res = curl_easy_setopt(self->handle, CURLOPT_USERAGENT, (char *) s);
+    free(s);
     if (res != CURLE_OK) {
-        free(s);
         return (-1);
     }
     return (0);


### PR DESCRIPTION
Each time a new Curl object is created util_curl_init() leaked
a small string buffer. The attached patch fixes the leak --
curl_easy_setopt() strdup's its argument; the caller does not need
to keep the buffer around for it.

https://sourceforge.net/p/pycurl/patches/13/
