### PR TITLE
Keep the default user agent around

### DIFF
--- a/src/pycurl.c
+++ b/src/pycurl.c
@@ -105,6 +105,9 @@ static void pycurl_ssl_cleanup(void);
 #define OPTIONS_SIZE    ((int)CURLOPT_LASTENTRY % 10000)
 #define MOPTIONS_SIZE   ((int)CURLMOPT_LASTENTRY % 10000)
 
+/* Keep some default variables around */
+static char *g_pycurl_useragent = NULL;
+
 /* Type objects */
 static PyObject *ErrorObject = NULL;
 static PyTypeObject *p_Curl_Type = NULL;
@@ -787,13 +790,7 @@ util_curl_init(CurlObject *self)
     }
 
     /* Set default USERAGENT */
-    s = (char *) malloc(7 + strlen(LIBCURL_VERSION) + 1);
-    if (s == NULL) {
-        return (-1);
-    }
-    strcpy(s, "PycURL/"); strcpy(s+7, LIBCURL_VERSION);
-    res = curl_easy_setopt(self->handle, CURLOPT_USERAGENT, (char *) s);
-    free(s);
+    res = curl_easy_setopt(self->handle, CURLOPT_USERAGENT, (char *) g_pycurl_useragent);
     if (res != CURLE_OK) {
         return (-1);
     }
@@ -3983,6 +3980,13 @@ initpycurl(void)
         Py_FatalError("pycurl: libcurl link-time version is older than compile-time version");
         assert(0);
     }
+    g_pycurl_useragent = (char *) malloc(7 + strlen(vi->version) + 1);
+    if (g_pycurl_useragent == NULL) {
+        Py_FatalError("pycurl: user-agent malloc() failed");
+        assert(0);
+    }
+    strcpy(g_pycurl_useragent, "PycURL/");
+    strcpy(g_pycurl_useragent+7, vi->version);
 
     /* Initialize callback locks if ssl is enabled */
 #if defined(PYCURL_NEED_SSL_TSL)


### PR DESCRIPTION
Nice to see that pycurl lives again! Here's a patch I submitted to Debian[1] too.

[1] http://bugs.debian.org/709226
