### PR TITLE
Use urlparse.urljoin instead of os.path.join

### DIFF
--- a/python/curl/__init__.py
+++ b/python/curl/__init__.py
@@ -6,11 +6,13 @@
 #
 # By Eric S. Raymond, April 2003.
 
-import os, sys, exceptions, mimetools, pycurl
+import sys, exceptions, mimetools, pycurl
 try:
     import urllib.parse as urllib_parse
+    from urllib.parse import urljoin
 except ImportError:
     import urllib as urllib_parse
+    from urlparse import urljoin
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -81,7 +83,7 @@ class Curl:
         if self.fakeheaders:
             self.set_option(pycurl.HTTPHEADER, self.fakeheaders)
         if relative_url:
-            self.set_option(pycurl.URL,os.path.join(self.base_url,relative_url))
+            self.set_option(pycurl.URL, urljoin(self.base_url, relative_url))
         self.payload = ""
         self.hdr = ""
         self.handle.perform()

--- a/tests/relative_url_test.py
+++ b/tests/relative_url_test.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python
+# -*- coding: iso-8859-1 -*-
+# vi:ts=4:et
+
+# uses the high level interface
+import curl
+import unittest
+
+from . import app
+from . import runwsgi
+from . import util
+
+setup_module, teardown_module = runwsgi.app_runner_setup((app.app, 8380))
+
+class RelativeUrlTest(unittest.TestCase):
+    def setUp(self):
+        self.curl = curl.Curl('http://localhost:8380/')
+    
+    def tearDown(self):
+        self.curl.close()
+    
+    def test_get_relative(self):
+        self.curl.get('/success')
+        self.assertEqual('success', self.curl.body())


### PR DESCRIPTION
Using a base_url like "http://www.google.de" and calling get("/") on a curl.Curl-instance does not work.

os.path.join("http://www.google.de", "/") does not yield the expected "http://www.google.de/" but "/" which leads to

error: (3, ' malformed')

Using urljoin fixes this.

https://github.com/christophwarner/PyCurl/pull/2
