### PR TITLE
Add nss ssl support, improve gnutls ssl support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,8 @@ else:
                 define_macros.append(('HAVE_CURL_OPENSSL', 1))
             if e[2:] == 'gnutls':
                 define_macros.append(('HAVE_CURL_GNUTLS', 1))
+            if e[2:] == 'ssl3':
+                define_macros.append(('HAVE_CURL_NSS', 1))
         elif e[:2] == "-L":
             library_dirs.append(e[2:])
         else:

--- a/src/pycurl.c
+++ b/src/pycurl.c
@@ -85,15 +85,18 @@ typedef int Py_ssize_t;
 #   define PYCURL_NEED_OPENSSL_TSL
 #   include <openssl/crypto.h>
 # elif defined(HAVE_CURL_GNUTLS)
-#   define PYCURL_NEED_SSL_TSL
-#   define PYCURL_NEED_GNUTLS_TSL
-#   include <gcrypt.h>
-# else
+#   include <gnutls/gnutls.h>
+#   if GNUTLS_VERSION_NUMBER <= 0x020b00
+#     define PYCURL_NEED_SSL_TSL
+#     define PYCURL_NEED_GNUTLS_TSL
+#     include <gcrypt.h>
+#   endif
+# elif !defined(HAVE_CURL_NSS)
 #  warning \
    "libcurl was compiled with SSL support, but configure could not determine which " \
    "library was used; thus no SSL crypto locking callbacks will be set, which may " \
    "cause random crashes on SSL requests"
-# endif /* HAVE_CURL_OPENSSL || HAVE_CURL_GNUTLS */
+# endif /* HAVE_CURL_OPENSSL || HAVE_CURL_GNUTLS || HAVE_CURL_NSS */
 #endif /* HAVE_CURL_SSL */
 
 #if defined(PYCURL_NEED_SSL_TSL)


### PR DESCRIPTION
This fixes two issues:

If curl is using a recent version of gnutls we do not need to initialize libgcrypt threading: gnutls does that for us. And because recent versions of gnutls may be using nettle instead of gcrypt it is important that we don't: those functions are not necessarily defined (and linking to libgcrypt explicitly to get them is stupid, as they're not used). The modification is based on instructions from the gnutls NEWS file.

If curl is using nss we do not seem to need to initialize threading explicitly: the only threading-related bit I see in the nss headers/documentation has to do with simultaneous non-nss use of pkcs11 modules, nss itself seems to be thread-safe by default. So silence the build warning.

http://sourceforge.net/p/pycurl/patches/15/
