### PR TITLE
Mark NSS as supported.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,8 @@ else:
                 define_macros.append(('HAVE_CURL_OPENSSL', 1))
             if e[2:] == 'gnutls':
                 define_macros.append(('HAVE_CURL_GNUTLS', 1))
+            if e[2:] == 'ssl3':
+                define_macros.append(('HAVE_CURL_NSS', 1))
         elif e[:2] == "-L":
             library_dirs.append(e[2:])
         else:

--- a/src/pycurl.c
+++ b/src/pycurl.c
@@ -88,12 +88,12 @@ typedef int Py_ssize_t;
 #   define PYCURL_NEED_SSL_TSL
 #   define PYCURL_NEED_GNUTLS_TSL
 #   include <gcrypt.h>
-# else
+# elif !defined(HAVE_CURL_NSS)
 #  warning \
    "libcurl was compiled with SSL support, but configure could not determine which " \
    "library was used; thus no SSL crypto locking callbacks will be set, which may " \
    "cause random crashes on SSL requests"
-# endif /* HAVE_CURL_OPENSSL || HAVE_CURL_GNUTLS */
+# endif /* HAVE_CURL_OPENSSL || HAVE_CURL_GNUTLS || HAVE_CURL_NSS */
 #endif /* HAVE_CURL_SSL */
 
 #if defined(PYCURL_NEED_SSL_TSL)


### PR DESCRIPTION
Mark NSS as supported, as it does not require the application to
initialize threading.

If curl is using nss we do not seem to need to initialize threading
explicitly: the only threading-related bit I see in the nss
headers/documentation has to do with simultaneous non-nss use of
pkcs11 modules, nss itself seems to be thread-safe by default.
So silence the build warning.

http://sourceforge.net/p/pycurl/patches/15/
