### PR TITLE
Only initialize gcrypt if we are using an older gnutls that needs this.

### DIFF
--- a/src/pycurl.c
+++ b/src/pycurl.c
@@ -85,9 +85,12 @@ typedef int Py_ssize_t;
 #   define PYCURL_NEED_OPENSSL_TSL
 #   include <openssl/crypto.h>
 # elif defined(HAVE_CURL_GNUTLS)
-#   define PYCURL_NEED_SSL_TSL
-#   define PYCURL_NEED_GNUTLS_TSL
-#   include <gcrypt.h>
+#   include <gnutls/gnutls.h>
+#   if GNUTLS_VERSION_NUMBER <= 0x020b00
+#     define PYCURL_NEED_SSL_TSL
+#     define PYCURL_NEED_GNUTLS_TSL
+#     include <gcrypt.h>
+#   endif
 # elif !defined(HAVE_CURL_NSS)
 #  warning \
    "libcurl was compiled with SSL support, but configure could not determine which " \


### PR DESCRIPTION
This is necessary to support newer gnutls linked to libnettle instead
of libgcrypt.

If curl is using a recent version of gnutls we do not need to initialize
libgcrypt threading: gnutls does that for us. And because recent versions
of gnutls may be using nettle instead of gcrypt it is important that we
don't: those functions are not necessarily defined (and linking to
libgcrypt explicitly to get them is stupid, as they're not used). The
modification is based on instructions from the gnutls NEWS file.

http://sourceforge.net/p/pycurl/patches/15/
