### PR TITLE
Added support for CURLOPT_RESOLVE

### DIFF
--- a/tests/resolve_test.py
+++ b/tests/resolve_test.py
@@ -1,0 +1,22 @@
+# -*- coding: iso-8859-1 -*-
+
+import pycurl
+import unittest
+
+from . import app
+from . import runwsgi
+
+setup_module, teardown_module = runwsgi.app_runner_setup((app.app, 8380))
+
+class ResolveTest(unittest.TestCase):
+    def setUp(self):
+        self.curl = pycurl.Curl()
+    
+    def tearDown(self):
+        self.curl.close()
+    
+    def test_resolve(self):
+        self.curl.setopt(pycurl.URL, 'http://p.localhost:8380/success')
+        self.curl.setopt(pycurl.RESOLVE, ['p.localhost:8380:127.0.0.1'])
+        self.curl.perform()
+        self.assertEqual(200, self.curl.getinfo(pycurl.RESPONSE_CODE))


### PR DESCRIPTION
libcurl 7.21.3 introduces CURLOPT_RESOLVE. Here's a patch providing support for it. I really don't like the bunch of #ifdef's required to implement it without bumping up the minimal libcurl version required. But perhaps it's not such a bad idea since 7.21.3 is from Dec 2010...

http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTRESOLVE
